### PR TITLE
Fix get order status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.12.x
   - 1.13.x
 env:
   - GO111MODULE=on

--- a/client.go
+++ b/client.go
@@ -265,7 +265,8 @@ func (cl *Client) GetOrderStatus(req []*InternalOrderNumber) ([]*OrderStatus, er
 	}{
 		operationGetOrderStatus{
 			&getOrderStatus{
-				&getOrderStatusRequest{
+				Namespace: orderNamespace,
+				OrderStatus: &getOrderStatusRequest{
 					Auth:  cl.auth,
 					Order: req,
 				},

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/vseinstrumentiru/dpd
 
 require github.com/fiorix/wsdl2go v1.4.6
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/SteppenHorde/dpd
+module github.com/vseinstrumentiru/dpd
 
 require github.com/fiorix/wsdl2go v1.4.6
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vseinstrumentiru/dpd
+module github.com/SteppenHorde/dpd
 
 require github.com/fiorix/wsdl2go v1.4.6
 

--- a/order2.go
+++ b/order2.go
@@ -211,10 +211,12 @@ type operationGetOrderStatus struct {
 }
 
 type getOrderStatus struct {
+	Namespace   string  `xml:"xmlns,attr"`
 	OrderStatus *getOrderStatusRequest `xml:"orderStatus,omitempty"`
 }
 
 type getOrderStatusRequest struct {
+	Namespace   string  `xml:"xmlns,attr"`
 	Auth  *Auth                  `xml:"auth,omitempty"`
 	Order []*InternalOrderNumber `xml:"order,omitempty"`
 }

--- a/order2.go
+++ b/order2.go
@@ -211,14 +211,14 @@ type operationGetOrderStatus struct {
 }
 
 type getOrderStatus struct {
-	Namespace   string  `xml:"xmlns,attr"`
+	Namespace   string                 `xml:"xmlns,attr"`
 	OrderStatus *getOrderStatusRequest `xml:"orderStatus,omitempty"`
 }
 
 type getOrderStatusRequest struct {
-	Namespace   string  `xml:"xmlns,attr"`
-	Auth  *Auth                  `xml:"auth,omitempty"`
-	Order []*InternalOrderNumber `xml:"order,omitempty"`
+	Namespace string                 `xml:"xmlns,attr"`
+	Auth      *Auth                  `xml:"auth,omitempty"`
+	Order     []*InternalOrderNumber `xml:"order,omitempty"`
 }
 
 //InternalOrderNumber GetOrderStatus request body. Imply client side oder number


### PR DESCRIPTION
Добавил недостающие поля в структуры запроса метода getOrderStatus (DPD возвращал ответ со статусом 500 и указанием на то, что не может распарсить реквест)