### PR TITLE
fix xml generation for order creation

### DIFF
--- a/client.go
+++ b/client.go
@@ -170,7 +170,8 @@ func (cl *Client) CreateOrder(req *CreateOrderRequest) ([]*OrderStatus, error) {
 	}{
 		operationCreateOrder{
 			&createOrder{
-				req,
+				Namespace: orderNamespace,
+				Orders:    req,
 			},
 		},
 	}

--- a/order2.go
+++ b/order2.go
@@ -103,14 +103,16 @@ type operationCreateOrder struct {
 }
 
 type createOrder struct {
-	Orders *CreateOrderRequest `xml:"orders,omitempty"`
+	Namespace string              `xml:"xmlns,attr"`
+	Orders    *CreateOrderRequest `xml:"orders,omitempty"`
 }
 
 //CreateOrderRequest CreateOrder request body
 type CreateOrderRequest struct {
-	Auth   *Auth    `xml:"auth,omitempty"`
-	Header *Header  `xml:"header,omitempty"`
-	Order  []*Order `xml:"order,omitempty"`
+	Namespace string   `xml:"xmlns,attr"`
+	Auth      *Auth    `xml:"auth,omitempty"`
+	Header    *Header  `xml:"header,omitempty"`
+	Order     []*Order `xml:"order,omitempty"`
 }
 
 //Order to creation


### PR DESCRIPTION
fix xml request generation for createOrder
> 500 Internal Server Error": "<?xml version='1.0' encoding='UTF-8'?><S:Envelope xmlns:S=\"http://schemas.xmlsoap.org/soap/envelope/\"><S:Body><S:Fault xmlns:ns4=\"http://www.w3.org/2003/05/soap-envelope\"><faultcode>S:Client</faultcode><faultstring>org.xml.sax.SAXParseException; cvc-elt.1: Cannot find the declaration of element 'createOrder'.</faultstring></S:Fault></S:Body></S:Envelope>

before (invalid)
```
<createOrder>
    <orders>
```
now (valid)
```
<createOrder xmlns="http://dpd.ru/ws/order2/2012-04-04">
    <orders xmlns="">
```